### PR TITLE
add binding to reload $MYVIMRC

### DIFF
--- a/layers/+nav/files/config.vim
+++ b/layers/+nav/files/config.vim
@@ -8,3 +8,4 @@ let g:lmap.f.e = { 'name': 'spaceneovim/files' }
 call SpaceNeovimNMap('fed', 'find-config-file', 'e $MYVIMRC')
 call SpaceNeovimNMap('feU', 'update-spaceneovim-layers', 'UpdateSpaceNeovimLayers')
 call SpaceNeovimNMap('fep', 'update-plugins', 'PlugInstall!')
+call SpaceNeovimNMap('feR', 'reload-config-file', 'source $MYVIMRC')


### PR DESCRIPTION
This PR introduces a new binding in the `+Files` layer that allows a user to reload the config file using `feR` this is the same binding that is being used by SpaceMacs for this functionality.
