### PR TITLE
Fix shortcut name typo in toggles layer

### DIFF
--- a/layers/+ui/toggles/README.md
+++ b/layers/+ui/toggles/README.md
@@ -5,6 +5,7 @@
 * [Description](#description)
 * [Install](#install)
   * [Layer](#layer)
+* [Key Bindings](#key-bindings)
 
 
 ## Description
@@ -17,3 +18,19 @@ This layer provides toggles for various things.
 ### Layer
 
 To use this configuration layer, add it to your `./config/nvim/init.vim`. You will need to add `+ui/toggles` to the existing dotspacevim_configuration_layers list in this file.
+
+
+## Key Bindings
+
+| Key Binding | Description                                     |
+|-------------|-------------------------------------------------|
+| SPC t n     | Toggle line numbers                             |
+| SPC t r     | Toggle relative line numbers                    |
+| SPC t l     | Toggle truncating lines                         |
+| SPC t s     | Toggle syntax highlighting                      |
+| SPC t S     | Toggle spell checking                           |
+| SPC t H     | Toggle showing hidden symbols                   |
+| SPC t h c   | Toggle highlight for current line indentation   |
+| SPC t h h   | Toggle highlight for current line               |
+| SPC t h p   | Toggle highlight for parenthesis                |
+| SPC t h s   | Toggle highlight for search results             |

--- a/layers/+ui/toggles/config.vim
+++ b/layers/+ui/toggles/config.vim
@@ -1,21 +1,24 @@
 call SpaceNeovimLoadFunc(expand('<sfile>:p'), 'func.vim')
 
+" Show invisible characters
+set list
+
 if &termencoding ==# 'utf-8' || &encoding ==# 'utf-8'
-     set listchars=extends:>,precedes:<,tab:▶\ ,trail:•
+  set listchars=extends:>,precedes:<,tab:▶\ ,trail:•
 else
-     set listchars=extends:>,precedes:<,tab:>\ ,trail:~
+  set listchars=extends:>,precedes:<,tab:>\ ,trail:~
 endif
 
 let g:lmap.t = { 'name': '+toggles' }
 call SpaceNeovimNMap('tn', 'line-numbers', 'setlocal invnumber')
 call SpaceNeovimNMap('tr', 'relative-line-numbers', 'setlocal invrelativenumber')
 call SpaceNeovimNMap('tl', 'truncate-lines', 'setlocal invwrap')
-call SpaceNeovimNMap('ts', 'syntax-checking', 'call SpaceNeovimToggleSyntax()')
+call SpaceNeovimNMap('ts', 'syntax-highlighting', 'call SpaceNeovimToggleSyntax()')
 call SpaceNeovimNMap('tS', 'spell-checking', 'setlocal invspell')
 call SpaceNeovimNMap('tH', 'hidden-symbols', 'set list!')
 
 let g:lmap.t.h = { 'name': '+highlight' }
-call SpaceNeovimNMap('thh', 'highlight-current-line-globally', 'setlocal invcursorline')
 call SpaceNeovimNMap('thc', 'highlight-indentation-current-column', 'setlocal invcursorcolumn')
+call SpaceNeovimNMap('thh', 'highlight-current-line-globally', 'setlocal invcursorline')
 call SpaceNeovimNMap('thp', 'parenthesis-highlight-mode', 'setlocal invshowmatch')
 call SpaceNeovimNMap('ths', 'highlight-search', 'set hlsearch!')


### PR DESCRIPTION
I believe shortcut should be named `syntax-highlighting` instead of `syntax-checking`.

I've also updated README with list of all key bindings.