### PR TITLE
[+scm/git] Use fzf instead of gv for git log, if +nav/fzf is enabled

### DIFF
--- a/layers/+scm/git/config.vim
+++ b/layers/+scm/git/config.vim
@@ -1,9 +1,15 @@
 let g:lmap.g = get(g:lmap, 'g', { 'name': '+git' })
 SpNMap  'gc', 'commit', 'Gcommit'
-SpNMap  'gl', 'log', 'GV'
-SpNMap  'gL', 'log-current-file', 'GV!'
 SpNMap  'gp', 'push-current-branch', 'PushToCurrentBranch'
 SpNMap  'gs', 'status', 'Gstatus'
+
+if SpaceNeovimIsLayerEnabled('+nav/fzf')
+  SpNMap  'gl', 'log', 'Commits!'
+  SpNMap  'gL', 'log-current-file', 'BCommits!'
+else
+  SpNMap  'gl', 'log', 'GV'
+  SpNMap  'gL', 'log-current-file', 'GV!'
+endif
 
 " Disable default mapping for git gutter
 let g:gitgutter_map_keys = 0

--- a/layers/+scm/git/packages.vim
+++ b/layers/+scm/git/packages.vim
@@ -2,7 +2,9 @@
 SpAddPlugin 'airblade/vim-gitgutter'
 
 " Browse Git commits nicely
-SpAddPlugin 'junegunn/gv.vim'
+if !SpaceNeovimIsLayerEnabled('+nav/fzf')
+  SpAddPlugin 'junegunn/gv.vim'
+endif
 
 " Git commands
 SpAddPlugin 'tpope/vim-fugitive'


### PR DESCRIPTION
Both `gv.vim` and `fzf.vim` are written by `junegunn`. They provide similar functionality for git log, while the latter also enables fuzzy searching. If we have `fzf.vim`, then we no longer need `gv.vim`.