### PR TITLE
[+core/behavior] Fix conflict with +nav/fzf and use ripgrep if available

### DIFF
--- a/layers/+core/behavior/config.vim
+++ b/layers/+core/behavior/config.vim
@@ -4,11 +4,3 @@ set ttimeoutlen=0
 
 " Read modelines from files
 set modeline
-
-" Use the silver searcher if available
-if executable('ag')
-  " Define Ag command to search for the provided text and open a quickfix
-  command -nargs=+ -complete=file -bar Ag silent! grep! <args>|cwindow|redraw!
-  " Use ag as grep method
-  set grepprg=ag\ --nogroup\ --nocolor
-endif

--- a/layers/+core/behavior/func.vim
+++ b/layers/+core/behavior/func.vim
@@ -1,0 +1,17 @@
+" Use ripgrep or the silver searcher if available
+if executable('rg')
+  if !SpaceNeovimIsLayerEnabled('+nav/fzf')
+    " Define Rg command to search for the provided text and open a quickfix
+    command! -nargs=+ -complete=file -bar Rg silent! grep! <args>|cwindow|redraw!
+  endif
+  " Use rg as grep method
+  set grepprg=rg\ --vimgrep
+  set grepformat^=%f:%l:%c:%m
+elseif executable('ag')
+  if !SpaceNeovimIsLayerEnabled('+nav/fzf')
+    " Define Ag command to search for the provided text and open a quickfix
+    command! -nargs=+ -complete=file -bar Ag silent! grep! <args>|cwindow|redraw!
+  endif
+  " Use ag as grep method
+  set grepprg=ag\ --nogroup\ --nocolor
+endif


### PR DESCRIPTION
Previously, the `Ag` command was defined both in `+core/behavior` and in `+nav/fzf`. Along with fixing this issue, I also added the `ripgrep` counterpart and moved the code from `config.vim` to `func.vim`.