### PR TITLE
[+tools/language-server] Avoid duplicating the mode text if airline is enabled

### DIFF
--- a/layers/+tools/language-server/config.vim
+++ b/layers/+tools/language-server/config.vim
@@ -17,8 +17,12 @@
   let g:LanguageClient_serverCommands = get(g:, 'LanguageClient_serverCommands', {})
   " Required for operations modifying multiple buffers like rename.
   set hidden
-  " Make the command line higher for echodoc.
-  set cmdheight=2
+  " Adjust the command line for echodoc.
+  if SpaceNeovimIsLayerEnabled('+ui/airline')
+    set noshowmode
+  else
+    set cmdheight=2
+  endif
   set shortmess=a
   " Do not automatically start language clients.
   let g:LanguageClient_autoStart = 0


### PR DESCRIPTION
To avoid the mode text overwriting [echodoc](https://github.com/Shougo/echodoc.vim)'s text, rather than raising the height of the command line, just don't show the mode text. It's safe to do so because airline already shows the mode.