### PR TITLE
[+docs/zeal] Add support for the offline documentation browser Zeal

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,49 +13,50 @@ Managing layers to use with [SpaceNeovim](https://github.com/Tehnix/spaceneovim)
 
 ## Current Layers
 
-Name                   |Description
------------------------|-------------------------------------------
-[+core/behavior](layers/+core/behavior)         |Core functionality for SpaceNeovim
-[+core/sensible](layers/+core/sensible)         |Sensible default settings
-[+completion/deoplete](layers/+completion/deoplete)   |Auto-completion with deoplete
-[+completion/snippets](layers/+completion/snippets)   |Snippet support
-[+checkers/ale](layers/+checkers/ale)          |Syntax checking with Ale
-[+checkers/neomake](layers/+checkers/neomake)      |Syntax checking with Neomake
-[+checkers/syntastic](layers/+checkers/syntastic)    |Syntax checking with Syntastic
-[+gui/ide](layers/+gui/ide)            |An opinionated setup with VimR/Oni
-[+nav/buffers](layers/+nav/buffers)           |Common buffer functionality
-[+nav/comments](layers/+nav/comments)          |Manipulating comments
-[+nav/files](layers/+nav/files)             |Common file operations
-[+nav/fuzzy](layers/+nav/fuzzy)             |Fuzzy search for files, buffers and methods
-[+nav/fzf](layers/+nav/fzf)               |Fuzzy search using FZF
-[+nav/jump](layers/+nav/jump)               |Easy navigation inside files
-[+nav/navigation](layers/+nav/navigation)               |Easy navigation on screen
-[+nav/quit](layers/+nav/quit)              |Common quit functionality
-[+nav/start-screen](layers/+nav/start-screen)      |Add start screen when opening Neovim
-[+nav/text](layers/+nav/text)              |Common text operations
-[+nav/tmux](layers/+nav/tmux)              |Navigate between VIM and TMUX panes
-[+nav/windows](layers/+nav/windows)           |Common window functionality
-[+scm/git](layers/+scm/git)               |Git and fugitive support
-[+specs/testing](layers/+specs/testing)         |Run tests directly from the editor
-[+tools/format](layers/+tools/format)          |Format files
-[+tools/language-server](layers/+tools/language-server) |Language server support
-[+tools/multicursor](layers/+tools/multicursor)     |Support for multiple cursors
-[+tools/terminal](layers/+tools/terminal)        |Defaults and keybindings for the terminal
-[+ui/airline](layers/+ui/airline)            |Replace the status bar with airline
-[+ui/dynamic-cursor](layers/+ui/dynamic-cursor)     |Dynamically change the cursor depending on the mode
-[+ui/toggles](layers/+ui/toggles)            |Toggles for common components
+Name                                                    | Description
+------------------------------------------------------- | ---------------------------------------------------
+[+core/behavior](layers/+core/behavior)                 | Core functionality for SpaceNeovim
+[+core/sensible](layers/+core/sensible)                 | Sensible default settings
+[+completion/deoplete](layers/+completion/deoplete)     | Auto-completion with deoplete
+[+completion/snippets](layers/+completion/snippets)     | Snippet support
+[+checkers/ale](layers/+checkers/ale)                   | Syntax checking with Ale
+[+checkers/neomake](layers/+checkers/neomake)           | Syntax checking with Neomake
+[+checkers/syntastic](layers/+checkers/syntastic)       | Syntax checking with Syntastic
+[+docs/zeal](layers/+docs/zeal)                         | Browse offline documentation with Zeal
+[+gui/ide](layers/+gui/ide)                             | An opinionated setup with VimR/Oni
+[+nav/buffers](layers/+nav/buffers)                     | Common buffer functionality
+[+nav/comments](layers/+nav/comments)                   | Manipulating comments
+[+nav/files](layers/+nav/files)                         | Common file operations
+[+nav/fuzzy](layers/+nav/fuzzy)                         | Fuzzy search for files, buffers and methods
+[+nav/fzf](layers/+nav/fzf)                             | Fuzzy search using FZF
+[+nav/jump](layers/+nav/jump)                           | Easy navigation inside files
+[+nav/navigation](layers/+nav/navigation)               | Easy navigation on screen
+[+nav/quit](layers/+nav/quit)                           | Common quit functionality
+[+nav/start-screen](layers/+nav/start-screen)           | Add start screen when opening Neovim
+[+nav/text](layers/+nav/text)                           | Common text operations
+[+nav/tmux](layers/+nav/tmux)                           | Navigate between VIM and TMUX panes
+[+nav/windows](layers/+nav/windows)                     | Common window functionality
+[+scm/git](layers/+scm/git)                             | Git and fugitive support
+[+specs/testing](layers/+specs/testing)                 | Run tests directly from the editor
+[+tools/format](layers/+tools/format)                   | Format files
+[+tools/language-server](layers/+tools/language-server) | Language server support
+[+tools/multicursor](layers/+tools/multicursor)         | Support for multiple cursors
+[+tools/terminal](layers/+tools/terminal)               | Defaults and keybindings for the terminal
+[+ui/airline](layers/+ui/airline)                       | Replace the status bar with airline
+[+ui/dynamic-cursor](layers/+ui/dynamic-cursor)         | Dynamically change the cursor depending on the mode
+[+ui/toggles](layers/+ui/toggles)                       | Toggles for common components
 
 Language layers
 
-Name             | Description
----------------- | -------------------------------------------
-[+lang/-example](layers/+lang/-example)   | A template for creating new language layers
-[+lang/elm](layers/+lang/elm)        | Support for Elm
-[+lang/haskell](layers/+lang/haskell)    | Support for Haskell
+Name                                        | Description
+------------------------------------------- | -------------------------------------------
+[+lang/-example](layers/+lang/-example)     | A template for creating new language layers
+[+lang/elm](layers/+lang/elm)               | Support for Elm
+[+lang/haskell](layers/+lang/haskell)       | Support for Haskell
 [+lang/javascript](layers/+lang/javascript) | Support for JavaScript
-[+lang/python](layers/+lang/python)     | Support for python
-[+lang/ruby](layers/+lang/ruby)       | Support for ruby
-[+lang/vim](layers/+lang/vim)        | Support for vim
+[+lang/python](layers/+lang/python)         | Support for python
+[+lang/ruby](layers/+lang/ruby)             | Support for ruby
+[+lang/vim](layers/+lang/vim)               | Support for vim
 
 ## Adding a New Layer
 

--- a/layers/+docs/zeal/README.md
+++ b/layers/+docs/zeal/README.md
@@ -1,0 +1,23 @@
+# Zeal Layer
+This layer adds support for the offline documentation browser [Zeal](https://zealdocs.org/), via [`KabbAmine/zeavim.vim`](https://github.com/KabbAmine/zeavim.vim). Check out the plugin for more information on how to configure it.
+
+#### Table of Contents
+- [Install](#install)
+- [Key Bindings](#key-bindings)
+
+## Install
+Add the `+docs/zeal` layer in your configuration file,
+
+```viml
+function! Layers()
+  " ...
+  Layer '+docs/zeal'
+  " ...
+endfunction
+```
+
+## Key Bindings
+Key Binding | Description
+----------- | ----------------------------------------------------------------
+SPC d d     | Search for the word under cursor or the current visual selection
+SPC d D     | Search with a docset and a query

--- a/layers/+docs/zeal/config.vim
+++ b/layers/+docs/zeal/config.vim
@@ -1,0 +1,4 @@
+let g:lmap.d = get(g:lmap, 'd', { 'name': '+docs' })
+SpNMap 'dd', 'zeal-word', 'Zeavim'
+SpVMap 'dd', 'zeal-selection', 'ZeavimV'
+SpNMap 'dD', 'zeal-query', 'Zeavim!'

--- a/layers/+docs/zeal/packages.vim
+++ b/layers/+docs/zeal/packages.vim
@@ -1,0 +1,1 @@
+SpAddPlugin 'KabbAmine/zeavim.vim'


### PR DESCRIPTION
[Zeal](https://zealdocs.org/) is an offline documentation browser for software developers. Spacemacs has a [layer](http://spacemacs.org/layers/+tools/dash/README.html) to support it. Feel free to change the key bindings :smile:.