### PR TITLE
[+completion/ncm2] Switch out nvim-completion-manager with NCM2

### DIFF
--- a/layers/+completion/ncm2/README.md
+++ b/layers/+completion/ncm2/README.md
@@ -1,18 +1,18 @@
-# NCM: nvim-completion-manager
+# NCM2
 This layer provides an asynchronous keyword completion system in the current buffer, using
 
-- [`nvim-completion-manager`](https://github.com/roxma/nvim-completion-manager).
+- [`NCM2`](https://github.com/ncm2/ncm2).
 
 #### Table of Contents
 - [Install](#install)
 
 ## Install
-Add the `+completion/nvim-completion-manager` layer in your configuration file,
+Add the `+completion/ncm2` layer in your configuration file,
 
 ```viml
 function! Layers()
   " ...
-  Layer '+completion/nvim-completion-manager'
+  Layer '+completion/ncm2'
   " ...
 endfunction
 ```

--- a/layers/+completion/ncm2/config.vim
+++ b/layers/+completion/ncm2/config.vim
@@ -1,0 +1,21 @@
+" suppress the annoying 'match x of y', 'The only match' and 'Pattern not
+" found' messages
+set shortmess+=c
+
+" CTRL-C doesn't trigger the InsertLeave autocmd . map to <ESC> instead.
+inoremap <c-c> <ESC>
+
+" When the <Enter> key is pressed while the popup menu is visible, it only
+" hides the menu. Use this mapping to close the menu and also start a new
+" line.
+inoremap <expr> <CR> (pumvisible() ? "\<c-y>\<cr>" : "\<CR>")
+
+" Use <TAB> to select the popup menu:
+inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
+"inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
+
+set completeopt=noinsert,menuone,noselect
+
+augroup NCMConfig
+  au BufEnter * call ncm2#enable_for_buffer()
+augroup END

--- a/layers/+completion/ncm2/packages.vim
+++ b/layers/+completion/ncm2/packages.vim
@@ -1,0 +1,44 @@
+" The core completion plugins.
+SpAddPlugin 'ncm2/ncm2'
+SpAddPlugin 'roxma/nvim-yarp'
+
+" Completion sources. {{{
+" This ncm2 plugin provide words from current buffer for completion.
+SpAddPlugin 'ncm2/ncm2-bufword'
+" Completions from other tmux panes.
+SpAddPlugin 'ncm2/ncm2-tmux'
+" Autocompletion for paths.
+SpAddPlugin 'ncm2/ncm2-path'
+" Autocomplation for GitHub.
+SpAddPlugin 'ncm2/ncm2-github'
+" Tags completions.
+SpAddPlugin 'ncm2/ncm2-tagprefix'
+" English Words completion using BSD look binary.
+SpAddPlugin 'filipekiss/ncm2-look.vim'
+" Syntax source for ncm2.
+SpAddPlugin 'Shougo/neco-syntax'
+SpAddPlugin 'ncm2/ncm2-syntax'
+
+" CSS.
+SpAddPlugin 'ncm2/ncm2-cssomni'
+" JavaScript.
+SpAddPlugin 'ncm2/ncm2-tern'
+" TypeScript.
+SpAddPlugin 'mhartington/nvim-typescript'
+" Python.
+SpAddPlugin 'ncm2/ncm2-jedi'
+" Rust.
+SpAddPlugin 'ncm2/ncm2-racer'
+" C/C++.
+SpAddPlugin 'ncm2/ncm2-pyclang'
+" Vimscript.
+SpAddPlugin 'ncm2/ncm2-vim'
+" Go.
+SpAddPlugin 'ncm2/ncm2-go'
+" PHP.
+SpAddPlugin 'phpactor/ncm2-phpactor'
+
+" Subscopes.
+SpAddPlugin 'ncm2/ncm2-html-subscope'
+SpAddPlugin 'ncm2/ncm2-markdown-subscope'
+" }}}

--- a/layers/+completion/nvim-completion-manager/config.vim
+++ b/layers/+completion/nvim-completion-manager/config.vim
@@ -1,9 +1,0 @@
-" Supress the annoying completion messages.
-set shortmess+=c
-
-" When the <Enter> key is pressed hide the menu and also start a new line.
-inoremap <expr> <CR> (pumvisible() ? "\<c-y>\<cr>" : "\<CR>")
-
-" Expanding snippet in the popup menu with <Enter> key. Suppose you use the <C-U> key for expanding snippet.
-imap <expr> <CR>  (pumvisible() ?  "\<c-y>\<Plug>(expand_or_nl)" : "\<CR>")
-imap <expr> <Plug>(expand_or_nl) (cm#completed_is_snippet() ? "\<C-U>":"\<CR>")

--- a/layers/+completion/nvim-completion-manager/packages.vim
+++ b/layers/+completion/nvim-completion-manager/packages.vim
@@ -1,1 +1,0 @@
-SpAddPlugin 'roxma/nvim-completion-manager'


### PR DESCRIPTION
Since nvim-completion-manager seems to have been taken over by NCM2, this replaces the layer. https://github.com/roxma/nvim-completion-manager.