### PR TITLE
Point vim-leader-guide to vviikk/vim-leader-guide-redux

### DIFF
--- a/layers/+core/behavior/packages.vim
+++ b/layers/+core/behavior/packages.vim
@@ -1,4 +1,5 @@
-" NOTE: We use the fork from https://github.com/spinks/vim-leader-guide, because
-" it supports more features, such as hiding descriptions in the leader guide menu.
-SpAddPlugin 'spinks/vim-leader-guide'
+" NOTE: We use the fork from https://github.com/vviikk/vim-leader-guide-redux
+" which is a backup of https://github.com/spinks/vim-leader-guide (but that repo went offline),
+" We need this as it has more features, such as hiding descriptions in the leader guide menu.
+SpAddPlugin 'vviikk/vim-leader-guide-redux'
 SpAddPlugin 'sheerun/vim-polyglot'


### PR DESCRIPTION
That repository has been taken offline sadly. This is just an exact backup.

Fixes #55 