### PR TITLE
Load vim-devicons after nerdtree-git-plugin

### DIFF
--- a/layers/+nav/files/packages.vim
+++ b/layers/+nav/files/packages.vim
@@ -1,6 +1,6 @@
 SpAddPlugin 'scrooloose/nerdtree'
 " Note: Download patched fonts from
 " https://github.com/ryanoasis/nerd-fonts/releases/tag/v1.2.0.
-SpAddPlugin 'ryanoasis/vim-devicons'
 SpAddPlugin 'Xuyuanp/nerdtree-git-plugin'
+SpAddPlugin 'ryanoasis/vim-devicons'
 SpAddPlugin 'dbakker/vim-projectroot'


### PR DESCRIPTION
As per this comment https://github.com/ryanoasis/vim-devicons/issues/223#issuecomment-570755111