### PR TITLE
Add Support for JSONC & JSON

### DIFF
--- a/layers/+lang/javascript/packages.vim
+++ b/layers/+lang/javascript/packages.vim
@@ -1,4 +1,5 @@
-SpAddPlugin 'elzr/vim-json'
+SpAddPlugin 'kevinoid/vim-jsonc'
+SpAddPlugin 'neoclide/jsonc.vim'
 SpAddPlugin 'mxw/vim-jsx'
 SpAddPlugin 'leafgarland/typescript-vim'
 SpAddPlugin 'Quramy/vim-js-pretty-template'


### PR DESCRIPTION
This is a much more recent and maintained JSON Plugin and it provides a lot more info.

A bonus is that it also supports comments as per JSONC schema. Optionally works better with language servers as well if using CoC.